### PR TITLE
Relax semantic versioning for moment package

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "buffer": "5.0.7",
     "crypto-js": "3.1.9-1",
-    "moment": "2.18.1",
+    "moment": "^2.18.1",
     "query-string": "5.0.0",
     "url-parse": "1.1.9"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1548,9 +1548,9 @@ mocha@^5.2.0:
     mkdirp "0.5.1"
     supports-color "5.4.0"
 
-moment@2.18.1:
-  version "2.18.1"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.18.1.tgz#c36193dd3ce1c2eed2adb7c802dbbc77a81b1c0f"
+moment@^2.18.1:
+  version "2.24.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
 
 ms@2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Constraining the exact version of package results in 99% of the cases in the need to include an extra version of the package to the bundle (which in case of `moment` is almost `52KB`).

With `^` we are solving this problem without a risk of introducing breaking changes.